### PR TITLE
dbh-pg leverage using() for resource management.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ with ```text``` for the query and ```values``` for the arguments.
 # Alternatives
 
 * [pg-promise](https://www.npmjs.com/package/pg-promise), a more generic Promises/A+ promisification of node-postgres with more features and more code. Does not leverage `using()` for resource management.
-* [dbh-pg](https://www.npmjs.com/package/dbh-pg), a node-postgres and bluebird specific library with it's own api for querying. Does not leverage `using()` for resource management.
+* [dbh-pg](https://www.npmjs.com/package/dbh-pg), a node-postgres and bluebird specific library with it's own api for querying.


### PR DESCRIPTION
Hi, [`dbh-pg`](https://www.npmjs.com/package/dbh-pg) uses `.using` since version 1.0.0! (2014-10-24)
