### PR TITLE
Implements support for Query Config Objects

### DIFF
--- a/test/connection-test.js
+++ b/test/connection-test.js
@@ -176,6 +176,12 @@ describe('connection-test.js', function () {
             assert.deepEqual(res.rows, [{bar: 1}])
           })
         }
+      }).then(function assertRowsObject(conn) {
+        return function () {
+          return conn.queryRowsAsync('SELECT bar from foo').then(function (rows) {
+            assert.deepEqual(rows, [{bar: 1}])
+          })
+        }
       })
     }
   }

--- a/test/query-object-test.js
+++ b/test/query-object-test.js
@@ -3,6 +3,7 @@
 var pgrm = require('../index.js')
 var configs = {dbUrl: "postgres://localhost/pgrm-tests"}
 var pgrmWithDefaults = pgrm(configs)
+var pgrmWithCustomKeys = pgrm(Object.assign(configs, {queryTextKey: 'customQueryTextKey', queryValuesKey: 'customQueryValuesKey'}))
 var using = require('bluebird').using
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -30,6 +31,13 @@ describe('queryAsync with a query object', function () {
         assert.equal(err, 'Error: Both query.values and args were passed to query. Please use only one of them.')
         return assertFooIsEventuallyEmpty()
       })
+  })
+
+  it('works with custom query text and values keys', function () {
+    return pgrmWithCustomKeys.queryRowsAsync({
+      customQueryTextKey: "insert into foo(bar) values ($1)",
+      customQueryValuesKey: [1]
+    }).then(assertOneEventuallyInFoo)
   })
 })
 

--- a/test/query-object-test.js
+++ b/test/query-object-test.js
@@ -1,0 +1,42 @@
+"use strict"; // eslint-disable-line semi
+
+var pgrm = require('../index.js')
+var configs = {dbUrl: "postgres://localhost/pgrm-tests"}
+var pgrmWithDefaults = pgrm(configs)
+var using = require('bluebird').using
+var chai = require('chai')
+var chaiAsPromised = require('chai-as-promised')
+var assert = chai.assert
+
+chai.use(chaiAsPromised)
+
+describe('queryAsync with a query object', function () {
+  beforeEach(function () {
+    return using(pgrmWithDefaults.getConnection(), function (conn) {
+      return conn.queryAsync("drop table if exists foo").then(function () {
+        return conn.queryAsync("create table foo(bar integer unique, id serial)")
+      })
+    })
+  })
+
+  it('behaves correctly when using query object', function () {
+    return pgrmWithDefaults.queryRowsAsync({text: "insert into foo(bar) values ($1)", values: [1]})
+      .then(assertOneEventuallyInFoo)
+  })
+
+  it('throws an error if args is passed when using query object', function () {
+    return pgrmWithDefaults.queryRowsAsync({text: "insert into foo(bar) values ($1)", values: [1]}, [1])
+      .catch(function (err) {
+        assert.equal(err, 'Error: Both query.values and args were passed to query. Please use only one of them.')
+        return assertFooIsEventuallyEmpty()
+      })
+  })
+})
+
+function assertOneEventuallyInFoo() {
+  return assert.eventually.deepEqual(pgrmWithDefaults.queryRowsAsync("select bar from foo"), [{bar: 1}])
+}
+
+function assertFooIsEventuallyEmpty() {
+  return assert.eventually.deepEqual(pgrmWithDefaults.queryRowsAsync("select bar from foo"), [])
+}


### PR DESCRIPTION
Implements support for Query Config Objects, https://node-postgres.com/features/queries#query-config-object i.e. support for passing query text and values (arguments) to query*Async functions in a object instead of separate query and args arguments. 

This makes it possible to use libraries such as https://github.com/felixfbecker/node-sql-template-strings.

This PR also adds the queryRowsAsync function to the client returned from getConnection and getTransaction.
  