### PR TITLE
Add withConnection and withTransaction helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,8 @@ module.exports = function (env) {
   return {
     getConnection: getConnectionWithEnv,
     getTransaction: getTransactionWithEnv,
+    withConnection: withConnection,
+    withTransaction: withTransaction,
     queryAsync: queryRowsWithEnv,
     queryRowsAsync: queryRowsWithEnv,
     createMultipleInsertCTE: createMultipleInsertCTE,
@@ -195,6 +197,7 @@ module.exports = function (env) {
     on: on,
     end: end
   }
+
 
   function getConnectionWithEnv() { return getConnection(queryConfig, connectMultiArgAsync) }
 
@@ -208,5 +211,13 @@ module.exports = function (env) {
 
   function end() {
     return pool.end()
+  }
+
+  function withConnection(statements) {
+    return using(getConnectionWithEnv(), statements)
+  }
+
+  function withTransaction(statements) {
+    return using(getTransactionWithEnv(), statements)
   }
 }

--- a/test/connection-test.js
+++ b/test/connection-test.js
@@ -145,6 +145,30 @@ describe('connection-test.js', function () {
 
   })
 
+  describe('withConnection', function () {
+    it('wraps using() and getConnection()', function () {
+      return pgrmWithDefaults.withConnection(assertResponseObj)
+    })
+
+    it('does not rollback errors', function () {
+      return pgrmWithDefaults.withConnection(function (conn) {
+        return insert1IntoFoo(conn).then(throwAnError)
+      }).catch(assertOneEventuallyInFoo)
+    })
+  })
+
+  describe('withTransaction', function () {
+    it('wraps using() and getTransaction()', function () {
+      return pgrmWithDefaults.withTransaction(assertResponseObj)
+    })
+
+    it('rolls back the transaction if the function throws', function () {
+      return pgrmWithDefaults.withTransaction(function (tx) {
+        return insert1IntoFoo(tx).then(throwAnError)
+      }).catch(assertFooIsEventuallyEmpty)
+    })
+  })
+
   function insert1IntoFoo(connOrTx) {
     return connOrTx.queryAsync("insert into foo(bar) values (1)")
   }


### PR DESCRIPTION
We see a lot of `using(getTransaction(), tx => ...)` kind of boilerplate in the digabi codebase. I'd like to simplify them to `withTransaction(tx => ...)`.